### PR TITLE
fix(patches): use updated additional_paths config

### DIFF
--- a/lib/webpacker/pnpm/patches.rb
+++ b/lib/webpacker/pnpm/patches.rb
@@ -11,11 +11,19 @@ module Webpacker
     Webpacker::Compiler.class_eval do
       def default_watched_paths
         [
-          *config.additional_paths_globbed,
+          *configured_paths
           config.source_path_globbed,
           "pnpm-lock.yaml", "package.json",
           "config/webpack/**/*"
         ].freeze
+      end
+
+      def configured_paths
+        if config.method_defined?(:additional_paths_globbed)
+          config.additional_paths_globbed
+        else
+          config.resolved_paths_globbed
+        end
       end
     end
 

--- a/lib/webpacker/pnpm/patches.rb
+++ b/lib/webpacker/pnpm/patches.rb
@@ -11,7 +11,7 @@ module Webpacker
     Webpacker::Compiler.class_eval do
       def default_watched_paths
         [
-          *config.resolved_paths_globbed,
+          *config.additional_paths_globbed,
           config.source_path_globbed,
           "pnpm-lock.yaml", "package.json",
           "config/webpack/**/*"


### PR DESCRIPTION
Resolves #2 

I added this fix locally and resolved the error mentioned in the referenced issue. This change would only support the latest major version of webpacker. I'm open to adding additional logic for folks still using previous major versions if required. 